### PR TITLE
Update: hero scrtion

### DIFF
--- a/color-picker-project/src/components/hero/Hero.css
+++ b/color-picker-project/src/components/hero/Hero.css
@@ -16,6 +16,8 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  margin-top: 4rem;
+  gap: 24px;
 }
 
 .header-span {
@@ -87,13 +89,6 @@
   position: absolute;
   inset: 0;
   z-index: 0;
-}
-
-@media (min-width: 420px) {
-  .content-container {
-    margin-top: 6rem;
-    gap: 16px;
-  }
 }
 
 @media (min-width: 776px) {


### PR DESCRIPTION
Fixes #40 removed the media query for min-width: 420px and applied these styles: margin-top: 4rem; gap: 24px to the .content-container selector.