### PR TITLE
Issue #72 - Fix bug with MaxWidthWrapper keys in Footer

### DIFF
--- a/color-picker-project/src/components/footer/Footer.jsx
+++ b/color-picker-project/src/components/footer/Footer.jsx
@@ -43,8 +43,8 @@ const Footer = ({ colorsTop }) => {
           <h1 className="footer-title">PalettePro</h1>
         </div>
 
-        {FooterMenu.map(({ title, links }) => (
-          <GenericColumn title={title} links={links} key={title} />
+        {FooterMenu.map(({ title, links }, index) => (
+          <GenericColumn title={title} links={links} key={index} />
         ))}
       </MaxWidthWrapper>
       <div className="footer-bottom">


### PR DESCRIPTION
In Footer.jsx, lines 46-47 I refactored FooterMenu.map to use index for the key instead of title, which gets rid of the console error about duplicate keys.